### PR TITLE
Specify Node 6.0 or greater in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "async": "2.x",
     "vows": "0.8.x"
   },
+  "engines":  {
+    "node" : ">=6.0"
+  },
   "peerDependencies": {
     "wintersmith": "2.x"
   },


### PR DESCRIPTION
Buffer.from was introduced in Node 6.0. This resolves #2. It should be possible
to run this package on versions prior to 6.0 using one of the many Buffer.from
polyfills. However, since Node 6.9.1 is the current LTS release I don’t believe
a Buffer.from polyfill should be a package dependency.